### PR TITLE
configure automated tests with tox and travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,62 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
 *.py[co]
 build/
 *.egg-info

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gevent"]
+	path = gevent
+	url = https://github.com/gevent/gevent.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python: 3.4
+env:
+  - TOX_ENV=py33
+  - TOX_ENV=py34
+  - TOX_ENV=lint
+install:
+  - pip install tox
+script:
+  - tox -e $TOX_ENV
+cache:
+  directories:
+    - .tox

--- a/known_failures.patch
+++ b/known_failures.patch
@@ -1,0 +1,27 @@
+--- known_failures.py	2015-06-28 14:33:12.270911380 +0100
++++ known_failures.py	2015-06-28 14:33:04.303661343 +0100
+@@ -107,6 +107,24 @@
+             FLAKY test__socket.py
+ '''.strip().split()
+ 
++FAILING_TESTS += '''
++    test__subprocess_poll.py
++    test_close_backend_fd.py
++    test_hub_join_timeout.py
++    test__example_udp_client.py
++    test_hub_join.py
++    test__subprocess.py
++    test_threading_2.py
++    test__destroy.py
++    test__server.py
++    test__doctests.py
++    test__core_stat.py
++    test__example_portforwarder.py
++    test__example_udp_server.py
++    test__environ.py
++    test_ares_timeout.py
++'''.strip().split()
++
+ 
+ if __name__ == '__main__':
+     import pprint

--- a/known_failures.patch
+++ b/known_failures.patch
@@ -1,6 +1,6 @@
 --- known_failures.py	2015-06-28 14:33:12.270911380 +0100
 +++ known_failures.py	2015-06-28 14:33:04.303661343 +0100
-@@ -107,6 +107,23 @@
+@@ -107,6 +107,26 @@
              FLAKY test__socket.py
  '''.strip().split()
  
@@ -20,6 +20,9 @@
 +    test__example_udp_server.py
 +    test__environ.py
 +'''.strip().split()
++
++if os.environ.get('GEVENT_FILE') == 'thread' or os.environ.get('GEVENT_RESOLVER') == 'thread':
++    FAILING_TESTS += 'FLAKY test__examples.py'
 +
  
  if __name__ == '__main__':

--- a/known_failures.patch
+++ b/known_failures.patch
@@ -1,6 +1,6 @@
 --- known_failures.py	2015-06-28 14:33:12.270911380 +0100
 +++ known_failures.py	2015-06-28 14:33:04.303661343 +0100
-@@ -107,6 +107,24 @@
+@@ -107,6 +107,23 @@
              FLAKY test__socket.py
  '''.strip().split()
  
@@ -19,7 +19,6 @@
 +    test__example_portforwarder.py
 +    test__example_udp_server.py
 +    test__environ.py
-+    test_ares_timeout.py
 +'''.strip().split()
 +
  

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+TOXINIDIR=$1
+ENVTMPDIR=$2
+
+mkdir -p "${ENVTMPDIR}"
+cp -r "${TOXINIDIR}/gevent" "${ENVTMPDIR}/gevent"
+(
+    cd "${ENVTMPDIR}/gevent"
+    patch < "${TOXINIDIR}/known_failures.patch"
+    make fulltoxtest
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = py{33,34}, lint
+
+[testenv]
+setenv =
+    GEVENT_LOOP = tulipcore.Loop
+commands = {toxinidir}/runtests.sh {toxinidir} {envtmpdir}
+deps =
+    py33: asyncio==3.4.3
+    cython==0.22.1
+    https://github.com/gevent/gevent/archive/454bced7b3a3e4feb0d8c101de290aacd36dac2d.tar.gz
+
+[testenv:lint]
+deps =
+    flake8==2.4.1
+    cython==0.22.1
+    https://github.com/gevent/gevent/archive/454bced7b3a3e4feb0d8c101de290aacd36dac2d.tar.gz
+commands=
+    flake8 tulipcore.py
+whitelist_externals=cp

--- a/tulipcore.py
+++ b/tulipcore.py
@@ -133,6 +133,8 @@ class IoWatcher(Watcher):
         self._writer = events & WRITE
 
     def _start(self, pass_events=False):
+        if pass_events:
+            self.args = (self.events,) + self.args
         if self._reader:
             self.loop.aio.add_reader(self.fd, self._invoke)
         if self._writer:

--- a/tulipcore.py
+++ b/tulipcore.py
@@ -119,6 +119,10 @@ class TimerWatcher(Watcher):
         self.active = False
         super()._invoke()
 
+    def again(self, callback, *args, **kwargs):
+        self.stop()
+        self.start(callback=callback, *args)
+
 
 class IoWatcher(Watcher):
     def __init__(self, loop, fd, events, ref=True, priority=None):


### PR DESCRIPTION
Using tox and a gevent submodule, run the tests as they are run on the real gevent repo but with our event loop.

To alter the ignored files, we need to patch the known_failures.py file to add the tests that fail in addition to the Py3k failures.

Some tests were impossible to ignore so I fixed them (see commits for details)